### PR TITLE
Fix: Call to a member function make() on null during package:discover

### DIFF
--- a/app/Console/Application.php
+++ b/app/Console/Application.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Application as Artisan;
+
+/**
+ * Artisan application that uses LaravelAwareCommandLoader so commands
+ * resolved from the container always have the Laravel app set (fixes
+ * "Call to a member function make() on null" during package:discover).
+ */
+class Application extends Artisan
+{
+    /**
+     * Set the container command loader for lazy resolution.
+     * Use our loader so resolved commands get setLaravel() called.
+     *
+     * @return $this
+     */
+    public function setContainerCommandLoader()
+    {
+        $this->setCommandLoader(new LaravelAwareCommandLoader($this->laravel, $this->commandMap));
+
+        return $this;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * Console kernel that uses our Application so commands loaded via the
+ * command loader get the Laravel app set (fixes package:discover error).
+ */
+class Kernel extends ConsoleKernel
+{
+    /**
+     * Get the Artisan application instance.
+     *
+     * @return \Illuminate\Console\Application
+     */
+    protected function getArtisan()
+    {
+        if (is_null($this->artisan)) {
+            $this->artisan = (new Application($this->app, $this->events, $this->app->version()))
+                ->resolveCommands($this->commands)
+                ->setContainerCommandLoader();
+
+            if ($this->symfonyDispatcher instanceof EventDispatcher) {
+                $this->artisan->setDispatcher($this->symfonyDispatcher);
+                $this->artisan->setSignalsToDispatchEvent();
+            }
+        }
+
+        return $this->artisan;
+    }
+}

--- a/app/Console/LaravelAwareCommandLoader.php
+++ b/app/Console/LaravelAwareCommandLoader.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ContainerCommandLoader;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+
+/**
+ * Wraps ContainerCommandLoader so that commands resolved from the container
+ * always have the Laravel application set on them (setLaravel).
+ *
+ * Works around Laravel issue where commands loaded via the command loader
+ * can run with $this->laravel === null, causing "Call to a member function
+ * make() on null" in Command::run() (e.g. during php artisan package:discover).
+ *
+ * @see https://github.com/laravel/framework/issues/56098
+ * @see https://github.com/laravel/framework/issues/58023
+ */
+class LaravelAwareCommandLoader extends ContainerCommandLoader
+{
+    /**
+     * Resolve a command from the container and ensure it has the Laravel app set.
+     */
+    public function get(string $name): SymfonyCommand
+    {
+        $command = parent::get($name);
+
+        if ($command instanceof Command) {
+            $command->setLaravel($this->container);
+        }
+
+        return $command;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,7 +4,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 
-return Application::configure(basePath: dirname(__DIR__))
+$builder = Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__ . '/../routes/web.php',
         api: __DIR__ . '/../routes/api.php',
@@ -65,4 +65,13 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //
-    })->create();
+    });
+
+$app = $builder->create();
+
+// Use custom Console Kernel so commands loaded via the command loader
+// get the Laravel app set (fixes "Call to a member function make() on null"
+// during php artisan package:discover - see Laravel issues #56098, #58023).
+$app->singleton(\Illuminate\Contracts\Console\Kernel::class, \App\Console\Kernel::class);
+
+return $app;


### PR DESCRIPTION
## Problem

Running `php artisan package:discover -vvv` (or `composer install`/`composer update` which triggers it) fails with:

```
Call to a member function make() on null
at vendor/laravel/framework/src/Illuminate/Console/Command.php:171
```

This is a known Laravel 12 bug ([#56098](https://github.com/laravel/framework/issues/56098), [#58023](https://github.com/laravel/framework/issues/58023)): commands loaded via the container command loader never get `setLaravel($app)` called, so `$this->laravel` is null when the command runs.

## Solution

Work around the bug by:

1. **LaravelAwareCommandLoader** – Extends Laravel’s `ContainerCommandLoader` and overrides `get()` so that after resolving a command it calls `setLaravel($this->container)` when the command is an `Illuminate\Console\Command`.

2. **Custom Console Application** – Uses `LaravelAwareCommandLoader` instead of `ContainerCommandLoader` in `setContainerCommandLoader()`.

3. **Custom Console Kernel** – Uses the custom Application in `getArtisan()`.

4. **bootstrap/app.php** – Registers the custom Console Kernel after creating the app.

## Testing

- `php artisan package:discover -vvv` runs successfully locally.
- No changes to application behavior; only fixes the broken command loader path.

Made with [Cursor](https://cursor.com)